### PR TITLE
Response data wrappers

### DIFF
--- a/lib/rubytoolbox/api.rb
+++ b/lib/rubytoolbox/api.rb
@@ -5,6 +5,12 @@ require "uri"
 require "json"
 require "net/http"
 require "rubytoolbox/api/response_wrapper"
+require "rubytoolbox/api/category"
+require "rubytoolbox/api/category_group"
+require "rubytoolbox/api/project"
+require "rubytoolbox/api/health"
+require "rubytoolbox/api/rubygem"
+require "rubytoolbox/api/github_repo"
 
 module Rubytoolbox
   class Api
@@ -23,7 +29,10 @@ module Rubytoolbox
       url = URI(File.join(endpoint_url, "projects", "compare", names.join(",")))
 
       data = handle_response! Net::HTTP.get_response(url)
-      data.fetch("projects")
+
+      data.fetch("projects").map do |project_data|
+        Project.new project_data
+      end
     end
 
     private

--- a/lib/rubytoolbox/api.rb
+++ b/lib/rubytoolbox/api.rb
@@ -4,6 +4,7 @@ require "rubytoolbox/api/version"
 require "uri"
 require "json"
 require "net/http"
+require "rubytoolbox/api/response_wrapper"
 
 module Rubytoolbox
   class Api

--- a/lib/rubytoolbox/api/category.rb
+++ b/lib/rubytoolbox/api/category.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Rubytoolbox
+  class Api
+    class Category < ResponseWrapper
+      class UrlSet < ResponseWrapper
+        field :toolbox_url
+      end
+
+      field :permalink
+      field :name
+      field :description
+      field :category_group do |category_group|
+        CategoryGroup.new category_group
+      end
+      field :urls do |urls|
+        UrlSet.new urls
+      end
+    end
+  end
+end

--- a/lib/rubytoolbox/api/category_group.rb
+++ b/lib/rubytoolbox/api/category_group.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Rubytoolbox
+  class Api
+    class CategoryGroup < ResponseWrapper
+      field :permalink
+      field :name
+      field :description
+    end
+  end
+end

--- a/lib/rubytoolbox/api/github_repo.rb
+++ b/lib/rubytoolbox/api/github_repo.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "time"
+
+module Rubytoolbox
+  class Api
+    class GithubRepo < ResponseWrapper
+      class Stats < ResponseWrapper
+        field :stargazers_count
+        field :forks_count
+        field :watchers_count
+      end
+
+      class Issues < ResponseWrapper
+        field :url
+        field :open_count
+        field :closed_count
+        field :total_count
+        field :closure_rate, &:to_f
+      end
+
+      class PullRequests < ResponseWrapper
+        field :url
+        field :open_count
+        field :closed_count
+        field :merged_count
+        field :total_count
+        field :acceptance_rate, &:to_f
+      end
+
+      field :path
+      field :average_recent_committed_at do |time|
+        Time.parse(time)
+      end
+      field :description
+      field :is_archived
+      field :is_fork
+      field :is_mirror
+      field :license
+      field :primary_language
+
+      field :repo_pushed_at do |time|
+        Time.parse(time)
+      end
+
+      field :url
+      field :wiki_url
+
+      field :stats do |stats|
+        Stats.new stats
+      end
+
+      field :issues do |issues|
+        Issues.new issues
+      end
+
+      field :pull_requests do |pull_requests|
+        PullRequests.new pull_requests
+      end
+    end
+  end
+end

--- a/lib/rubytoolbox/api/health.rb
+++ b/lib/rubytoolbox/api/health.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Rubytoolbox
+  class Api
+    class Health < ResponseWrapper
+      class Status < ResponseWrapper
+        field :key
+        field :icon
+        field :label
+        field :level
+      end
+
+      field :overall_level
+      field :statuses do |statuses|
+        statuses.map do |status|
+          Status.new status
+        end
+      end
+    end
+  end
+end

--- a/lib/rubytoolbox/api/project.rb
+++ b/lib/rubytoolbox/api/project.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Rubytoolbox
+  class Api
+    class Project < ResponseWrapper
+      class UrlSet < ResponseWrapper
+        field :bug_tracker_url
+        field :changelog_url
+        field :documentation_url
+        field :homepage_url
+        field :mailing_list_url
+        field :source_code_url
+        field :toolbox_url
+        field :wiki_url
+      end
+
+      field :description
+      field :name
+      field :permalink
+      field :score, &:to_f
+
+      field :categories do |categories|
+        categories.map { |category| Category.new category }
+      end
+
+      field :github_repo do |github_repo|
+        GithubRepo.new github_repo
+      end
+
+      field :health do |health|
+        Health.new health
+      end
+
+      field :rubygem do |rubygem|
+        Rubygem.new rubygem
+      end
+
+      field :urls do |urls|
+        UrlSet.new urls
+      end
+    end
+  end
+end

--- a/lib/rubytoolbox/api/response_wrapper.rb
+++ b/lib/rubytoolbox/api/response_wrapper.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Rubytoolbox
+  class Api
+    #
+    # A simple base class for data wrapper objects / structs. Libraries like
+    # dry-struct are normally very handy for these things but to keep dependencies
+    # minimal we roll our own simple utility here.
+    #
+    # Usage:
+    #
+    #   class Foo < Rubytoolbox::Api::ResponseWrapper
+    #     field :foo
+    #     field :bar, &:reverse
+    #   end
+    #
+    #  Foo.new(foo: "foo", bar: "bar").bar # => "rab"
+    #
+    class ResponseWrapper
+      class << self
+        def field(name, &block)
+          fields << name.to_s
+
+          block ||= ->(value) { value }
+
+          define_method "#{name}=" do |value|
+            instance_variable_set "@#{name}", block.call(value)
+          end
+
+          attr_reader name
+          private "#{name}="
+        end
+
+        def fields
+          @fields ||= []
+        end
+      end
+
+      def initialize(data)
+        self.class.fields.each do |name|
+          send "#{name}=", data[name.to_s] || data[name.to_sym]
+        end
+      end
+    end
+  end
+end

--- a/lib/rubytoolbox/api/response_wrapper.rb
+++ b/lib/rubytoolbox/api/response_wrapper.rb
@@ -38,7 +38,9 @@ module Rubytoolbox
 
       def initialize(data)
         self.class.fields.each do |name|
-          send "#{name}=", data[name.to_s] || data[name.to_sym]
+          value = data.key?(name.to_s) ? data[name.to_s] : data[name.to_sym]
+
+          send "#{name}=", value unless value.nil?
         end
       end
     end

--- a/lib/rubytoolbox/api/rubygem.rb
+++ b/lib/rubytoolbox/api/rubygem.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Rubytoolbox
+  class Api
+    class Rubygem < ResponseWrapper
+      class Stats < ResponseWrapper
+        field :downloads
+        field :reverse_dependencies_count
+        field :releases_count
+
+        field :quarterly_release_counts
+      end
+
+      field :name
+      field :current_version
+      field :first_release_on do |date|
+        Date.parse(date)
+      end
+      field :latest_release_on do |date|
+        Date.parse(date)
+      end
+      field :licenses
+      field :url
+
+      field :stats do |stats|
+        Stats.new stats
+      end
+    end
+  end
+end

--- a/spec/fixtures/project.json
+++ b/spec/fixtures/project.json
@@ -1,0 +1,115 @@
+{
+  "permalink": "simplecov",
+  "categories": [
+    {
+      "permalink": "code_coverage",
+      "category_group": {
+        "permalink": "Code_Quality",
+        "description": null,
+        "name": "Code Quality"
+      },
+      "description": "Utilities that report which code is being run. Most commonly this is used as test coverage which reports what parts of your code are not tested, but there are also tools to find dead production code",
+      "name": "Code Coverage",
+      "urls": {
+        "toolbox_url": "https://www.ruby-toolbox.com/categories/code_coverage"
+      }
+    }
+  ],
+  "description": "Code coverage for Ruby with a powerful configuration library and automatic merging of coverage across test suites",
+  "github_repo": {
+    "path": "colszowka/simplecov",
+    "average_recent_committed_at": "2020-02-16T17:31:49.000Z",
+    "description": "Code coverage for Ruby 1.9+ with a powerful configuration library and automatic merging of coverage across test suites",
+    "is_archived": false,
+    "is_fork": false,
+    "is_mirror": false,
+    "issues": {
+      "url": "https://github.com/colszowka/simplecov/issues",
+      "open_count": 49,
+      "closed_count": 414,
+      "total_count": 463,
+      "closure_rate": "89.42"
+    },
+    "license": "mit",
+    "primary_language": "Ruby",
+    "pull_requests": {
+      "url": "https://github.com/colszowka/simplecov/pulls",
+      "open_count": 3,
+      "closed_count": 83,
+      "merged_count": 333,
+      "total_count": 419,
+      "acceptance_rate": "79.47"
+    },
+    "repo_pushed_at": "2020-03-11T15:23:47.000Z",
+    "stats": {
+      "stargazers_count": 3947,
+      "forks_count": 429,
+      "watchers_count": 64
+    },
+    "url": "https://github.com/colszowka/simplecov",
+    "wiki_url": null
+  },
+  "health": {
+    "overall_level": "green",
+    "statuses": [
+      {
+        "key": "rubygem_long_running",
+        "icon": "diamond",
+        "label": "A long-lived project that still receives updates",
+        "level": "green"
+      }
+    ]
+  },
+  "name": "simplecov",
+  "rubygem": {
+    "name": "simplecov",
+    "current_version": "0.18.5",
+    "first_release_on": "2010-08-21",
+    "latest_release_on": "2020-02-25",
+    "licenses": [
+      "MIT"
+    ],
+    "stats": {
+      "downloads": 92755493,
+      "reverse_dependencies_count": 10238,
+      "quarterly_release_counts": {
+        "2010-3": 6,
+        "2010-4": 1,
+        "2011-1": 3,
+        "2011-2": 1,
+        "2011-3": 2,
+        "2011-4": 1,
+        "2012-1": 2,
+        "2012-2": 3,
+        "2012-4": 2,
+        "2013-2": 1,
+        "2013-3": 1,
+        "2013-4": 2,
+        "2014-3": 2,
+        "2015-1": 1,
+        "2015-2": 1,
+        "2015-4": 2,
+        "2016-1": 1,
+        "2016-3": 1,
+        "2017-1": 3,
+        "2017-3": 2,
+        "2018-1": 2,
+        "2019-3": 2,
+        "2020-1": 9
+      },
+      "releases_count": 51
+    },
+    "url": "https://rubygems.org/gems/simplecov"
+  },
+  "score": "18.17",
+  "urls": {
+    "bug_tracker_url": "https://github.com/colszowka/simplecov/issues",
+    "changelog_url": null,
+    "documentation_url": "https://www.rubydoc.info/gems/simplecov/0.18.5",
+    "homepage_url": "https://github.com/colszowka/simplecov",
+    "mailing_list_url": "https://groups.google.com/forum/#!forum/simplecov",
+    "source_code_url": "https://github.com/colszowka/simplecov/tree/v0.18.5",
+    "toolbox_url": "https://www.ruby-toolbox.com/projects/simplecov",
+    "wiki_url": null
+  }
+}

--- a/spec/rubytoolbox/api/project_spec.rb
+++ b/spec/rubytoolbox/api/project_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+RSpec.describe Rubytoolbox::Api::Project do
+  let(:json) do
+    JSON.parse File.read(File.join(__dir__, "..", "..", "fixtures", "project.json"))
+  end
+  let(:project) { described_class.new(json) }
+
+  it "has project-related attributes" do
+    expect(project).to have_attributes(
+      permalink: "simplecov",
+      name: "simplecov",
+      description: /Code coverage for Ruby/,
+      score: kind_of(Float)
+    )
+  end
+
+  describe "#categories" do
+    it "has categories" do
+      expect(project.categories).to all(be_a(Rubytoolbox::Api::Category))
+    end
+
+    it "has expected category attributes" do
+      expect(project.categories.first).to have_attributes(
+        permalink: "code_coverage",
+        description: /^Utilities/,
+        name: "Code Coverage"
+      )
+    end
+
+    it "wraps category group" do
+      expect(project.categories.first.category_group)
+        .to be_a(Rubytoolbox::Api::CategoryGroup)
+        .and have_attributes(
+          permalink: "Code_Quality",
+          description: nil,
+          name: "Code Quality"
+        )
+    end
+
+    it "wraps urls" do
+      expect(project.categories.first.urls)
+        .to be_a(Rubytoolbox::Api::Category::UrlSet)
+        .and have_attributes(
+          toolbox_url: %r{categories/code_coverage}
+        )
+    end
+  end
+
+  describe "#health" do
+    it "is wrapped as health object" do
+      expect(project.health).to be_a(Rubytoolbox::Api::Health)
+        .and have_attributes(
+          overall_level: "green"
+        )
+    end
+
+    it "wraps all statuses" do
+      expect(project.health.statuses).to all(be_a(Rubytoolbox::Api::Health::Status))
+    end
+
+    it "has expected attributes on status" do
+      expect(project.health.statuses.first).to have_attributes(
+        key: "rubygem_long_running",
+        icon: "diamond",
+        label: /long-lived project/,
+        level: "green"
+      )
+    end
+  end
+
+  describe "#urls" do
+    # rubocop:disable RSpec/ExampleLength
+    it "is is a url set and has expected urls" do
+      expect(project.urls).to be_a(described_class::UrlSet)
+        .and have_attributes(
+          bug_tracker_url: "https://github.com/colszowka/simplecov/issues",
+          changelog_url: nil,
+          documentation_url: "https://www.rubydoc.info/gems/simplecov/0.18.5",
+          homepage_url: "https://github.com/colszowka/simplecov",
+          mailing_list_url: "https://groups.google.com/forum/#!forum/simplecov",
+          source_code_url: "https://github.com/colszowka/simplecov/tree/v0.18.5",
+          toolbox_url: "https://www.ruby-toolbox.com/projects/simplecov",
+          wiki_url: nil
+        )
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+
+  describe "#rubygem" do
+    it "is a wrapped rubygem" do
+      expect(project.rubygem).to be_a(Rubytoolbox::Api::Rubygem)
+        .and have_attributes(
+          name: "simplecov",
+          current_version: "0.18.5",
+          first_release_on: Date.new(2010, 8, 21),
+          latest_release_on: Date.new(2020, 2, 25),
+          licenses: %w[MIT],
+          url: "https://rubygems.org/gems/simplecov"
+        )
+    end
+
+    describe "#stats" do
+      let(:stats) { project.rubygem.stats }
+
+      it "is a stats object with expected attributes" do
+        expect(stats).to be_a(Rubytoolbox::Api::Rubygem::Stats)
+          .and have_attributes(
+            downloads: 92_755_493,
+            reverse_dependencies_count: 10_238,
+            releases_count: 51
+          )
+      end
+
+      it "has quarterly_release_counts" do
+        expect(stats.quarterly_release_counts).to be_a(Hash)
+          .and include("2012-4" => 2)
+      end
+    end
+  end
+
+  describe "#github_repo" do
+    let(:repo) { project.github_repo }
+
+    # rubocop:disable RSpec/ExampleLength
+    it "is a wrapped github repo with expected attributes" do
+      expect(repo).to be_a(Rubytoolbox::Api::GithubRepo)
+        .and have_attributes(
+          path: "colszowka/simplecov",
+          average_recent_committed_at: within(86_400).of(Date.new(2020, 2, 16).to_time),
+          description: /Code coverage/,
+          is_archived: false,
+          is_mirror: false,
+          is_fork: false,
+          license: "mit",
+          primary_language: "Ruby",
+          repo_pushed_at: within(86_400).of(Date.new(2020, 3, 11).to_time),
+          url: "https://github.com/colszowka/simplecov",
+          wiki_url: nil
+        )
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it "wraps issues info with expected attributes" do
+      expect(repo.issues).to be_a(Rubytoolbox::Api::GithubRepo::Issues)
+        .and have_attributes(
+          url: "https://github.com/colszowka/simplecov/issues",
+          open_count: 49,
+          closed_count: 414,
+          total_count: 463,
+          closure_rate: 89.42
+        )
+    end
+
+    it "wraps pull request info with expected attributes" do
+      expect(repo.pull_requests).to be_a(Rubytoolbox::Api::GithubRepo::PullRequests)
+        .and have_attributes(
+          url: "https://github.com/colszowka/simplecov/pulls",
+          open_count: 3,
+          closed_count: 83,
+          merged_count: 333,
+          total_count: 419,
+          acceptance_rate: 79.47
+        )
+    end
+
+    it "wraps stats with expected attributes" do
+      expect(repo.stats).to be_a(Rubytoolbox::Api::GithubRepo::Stats)
+        .and have_attributes(
+          stargazers_count: 3947,
+          forks_count: 429,
+          watchers_count: 64
+        )
+    end
+  end
+end

--- a/spec/rubytoolbox/api/response_wrapper_spec.rb
+++ b/spec/rubytoolbox/api/response_wrapper_spec.rb
@@ -14,4 +14,8 @@ RSpec.describe Rubytoolbox::Api::ResponseWrapper do
       bar: "rab"
     )
   end
+
+  it "correctly handles false value when given as string key" do
+    expect(sample.new("foo" => false, bar: "123").foo).to be == false
+  end
 end

--- a/spec/rubytoolbox/api/response_wrapper_spec.rb
+++ b/spec/rubytoolbox/api/response_wrapper_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Rubytoolbox::Api::ResponseWrapper do
+  sample = Class.new(described_class) do
+    field :foo
+    field :bar, &:reverse
+  end
+
+  it "wraps given data as attributes of the class" do
+    expect(sample.new(foo: "foo", bar: "bar")).to have_attributes(
+      foo: "foo",
+      bar: "rab"
+    )
+  end
+end


### PR DESCRIPTION
This PR adds a simple homebrew struct-like data wrapper alongside full objects for wrapping the projects response in proper ruby objects instead of having to juggle hashes and arrays of hashes.